### PR TITLE
fix: outdated `repository.url` in `package.json`

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -6,7 +6,7 @@
   "types": "index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/aleclarson/web-ext-cli-options.git"
+    "url": "git+https://github.com/aleclarson/web-ext-option-types.git"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
I noticed the repository and homepage links were broken on NPM.